### PR TITLE
build: Fix win scp

### DIFF
--- a/.github/workflows/desktop-build-github.yaml
+++ b/.github/workflows/desktop-build-github.yaml
@@ -123,8 +123,8 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
-          REMOTE_PATH: /var/www/singulatron
-          LOCAL_PATH: ./out
+          REMOTE_PATH: /var/www/singulatron/
+          LOCAL_PATH: ./out/make/squirrel.windows/x64/
         run: |
           Write-Host "Create a local directory for the SSH key within the working directory"
           $localSshDir = New-Item -ItemType Directory -Force -Path "./.ssh_automation_deploy"
@@ -142,7 +142,7 @@ jobs:
           ssh-keyscan $env:REMOTE_HOST | Out-File -Append -FilePath "$localSshDir\known_hosts"
 
           Write-Host "Create a version-specific folder on the server using the GIT_TAG"
-          $versionPath = "${env:REMOTE_PATH}/${env:GIT_TAG}/windows"
+          $versionPath = "${env:REMOTE_PATH}/${env:GIT_TAG}/windows/out/make/squirrel.windows/x64"
           ssh -o StrictHostKeyChecking=no -i $idRsaAutomationPath "${env:REMOTE_USER}@${env:REMOTE_HOST}" "mkdir -p $versionPath"
 
           Write-Host "Recursively copy the entire out directory to the server into the version-specific folder"

--- a/.github/workflows/desktop-build-github.yaml
+++ b/.github/workflows/desktop-build-github.yaml
@@ -30,11 +30,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-cache-
 
-      - name: Uninstall docker
-        run: |
-          Stop-Service -Name Docker
-          Get-WmiObject -Class Win32_Product | Where-Object { $_.Name -match "Docker" } | ForEach-Object { $_.Uninstall() }
-
       - name: Prepare environment variables
         run: |
           # Define the target executable and the symlink path

--- a/.github/workflows/desktop-build-github.yaml
+++ b/.github/workflows/desktop-build-github.yaml
@@ -142,7 +142,7 @@ jobs:
           ssh-keyscan $env:REMOTE_HOST | Out-File -Append -FilePath "$localSshDir\known_hosts"
 
           Write-Host "Create a version-specific folder on the server using the GIT_TAG"
-          $versionPath = "${env:REMOTE_PATH}/${env:GIT_TAG}/windows/out/make/squirrel.windows/x64"
+          $versionPath = "${env:REMOTE_PATH}/${env:GIT_TAG}/windows/out/make/squirrel.windows"
           ssh -o StrictHostKeyChecking=no -i $idRsaAutomationPath "${env:REMOTE_USER}@${env:REMOTE_HOST}" "mkdir -p $versionPath"
 
           Write-Host "Recursively copy the entire out directory to the server into the version-specific folder"

--- a/.github/workflows/desktop-build-github.yaml
+++ b/.github/workflows/desktop-build-github.yaml
@@ -30,6 +30,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-cache-
 
+      - name: Uninstall docker
+        run: |
+          Stop-Service -Name Docker
+          Get-WmiObject -Class Win32_Product | Where-Object { $_.Name -match "Docker" } | ForEach-Object { $_.Uninstall() }
+
       - name: Prepare environment variables
         run: |
           # Define the target executable and the symlink path

--- a/.github/workflows/desktop-build-github.yaml
+++ b/.github/workflows/desktop-build-github.yaml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - "desktop/**"
+      - "localtron/**"
       - ".github/workflows/desktop-build-github.yaml"
 
 jobs:

--- a/.github/workflows/desktop-build-github.yaml
+++ b/.github/workflows/desktop-build-github.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-windows:
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: windows-latest
     env:
       CGO_ENABLED: 0
@@ -209,7 +209,7 @@ jobs:
         working-directory: ./desktop
 
   build-macos:
-    timeout-minutes: 15
+    timeout-minutes: 10
     runs-on: macos-latest
     env:
       CGO_ENABLED: 0

--- a/desktop/workspaces/angular-app/src/app/services/localtron.service.ts
+++ b/desktop/workspaces/angular-app/src/app/services/localtron.service.ts
@@ -101,9 +101,11 @@ export class LocaltronService {
 					selectedExists: rsp?.status?.selectedExists,
 				});
 			} catch (error) {
-				console.error('Error in pollModelStatus', error);
+				console.error('Error in pollModelStatus', {
+					error: JSON.stringify(error),
+				});
 			}
-			setTimeout(pollModelStatus, 1000); // Call again after 1 second
+			setTimeout(pollModelStatus, 1000);
 		};
 
 		const pollDockerInfo = async () => {
@@ -114,9 +116,11 @@ export class LocaltronService {
 					hasDocker: rsp?.info?.hasDocker,
 				});
 			} catch (error) {
-				console.error('Error in pollDockerInfo', error);
+				console.error('Error in pollDockerInfo', {
+					error: JSON.stringify(error),
+				});
 			}
-			setTimeout(pollDockerInfo, 1000); // Call again after 1 second
+			setTimeout(pollDockerInfo, 1000);
 		};
 
 		const pollPromptList = async () => {
@@ -125,9 +129,11 @@ export class LocaltronService {
 
 				this.onPromptListUpdateSubject.next(rsp.prompts);
 			} catch (error) {
-				console.error('Error in pollPromptList', error);
+				console.error('Error in pollPromptList', {
+					error: JSON.stringify(error),
+				});
 			}
-			setTimeout(pollPromptList, 1000); // Call again after 1 second
+			setTimeout(pollPromptList, 1000);
 		};
 
 		const pollConfig = async () => {
@@ -136,9 +142,11 @@ export class LocaltronService {
 				this.lapi.lastConfig = rsp?.config;
 				this.lapi.onConfigUpdateSubject.next(rsp?.config as Config);
 			} catch (error) {
-				console.error('Error in pollConfig', error);
+				console.error('Error in pollConfig', {
+					error: JSON.stringify(error),
+				});
 			}
-			setTimeout(pollConfig, 1000); // Call again after 1 second
+			setTimeout(pollConfig, 1000);
 		};
 
 		const pollFileDownloadStatus = async () => {
@@ -148,12 +156,13 @@ export class LocaltronService {
 					allDownloads: rsp?.downloads as DownloadDetails[],
 				});
 			} catch (error) {
-				console.error('Error in pollFileDownloadStatus', error);
+				console.error('Error in pollFileDownloadStatus', {
+					error: JSON.stringify(error),
+				});
 			}
-			setTimeout(pollFileDownloadStatus, 1000); // Call again after 1 second
+			setTimeout(pollFileDownloadStatus, 1000);
 		};
 
-		// Start the polling loops
 		pollModelStatus();
 		pollDockerInfo();
 		pollPromptList();
@@ -597,7 +606,7 @@ export interface DeleteChatThreadRequest {
 }
 
 export interface DeleteChatMessageRequest {
-	messageId: string; // Corrected field name from "threadId" to "messageId"
+	messageId: string;
 }
 
 export interface GetChatThreadRequest {

--- a/desktop/workspaces/electron-app/main/components/app.ts
+++ b/desktop/workspaces/electron-app/main/components/app.ts
@@ -44,13 +44,11 @@ export class App {
 
 			setupSession();
 
-			registerShortcuts(
-				App._wrapper.electronWindow as BrowserWindow,
-				globalShortcut
-			);
-
 			ipcMain.on(WindowApiConst.FRONTEND_READY_REQUEST, (event, args) => {
 				console.log('Frontend ready');
+
+				registerShortcuts(App.electronWindow as BrowserWindow, globalShortcut);
+
 
 				try {
 					const systemLanguage: string = app.getLocale().split('-')[0];

--- a/desktop/workspaces/electron-app/main/components/app.ts
+++ b/desktop/workspaces/electron-app/main/components/app.ts
@@ -49,7 +49,6 @@ export class App {
 
 				registerShortcuts(App.electronWindow as BrowserWindow, globalShortcut);
 
-
 				try {
 					const systemLanguage: string = app.getLocale().split('-')[0];
 					App.electronWindow?.webContents.send(

--- a/desktop/workspaces/electron-app/main/components/logger.ts
+++ b/desktop/workspaces/electron-app/main/components/logger.ts
@@ -9,7 +9,6 @@
  * For commercial licensing inquiries, please contact The Authors listed in the AUTHORS file.
  */
 import * as fs from 'fs';
-import * as util from 'util';
 import { homedir } from 'os';
 import { join } from 'path';
 import { sendLogToLocalServer } from '../ipc-handlers/log-request';

--- a/desktop/workspaces/electron-app/main/the-machine/os_manager.ts
+++ b/desktop/workspaces/electron-app/main/the-machine/os_manager.ts
@@ -27,20 +27,21 @@ export class OSManager {
 		private eventService: EventService
 	) {
 		this.eventService.installRuntimeRequest$.subscribe(() => {
+			console.info('Install runtime initiated');
 			this.initializeEnvironment();
 		});
 
 		// @todo fix path, config service is now in localtron
 		this.logFilePath = path.join(os.homedir(), 'singulatron_install.log');
 
-		this.init();
+		this.initLogFile();
 
 		new FileWatcher(this.logFilePath, (log) => {
 			this.eventService.onRuntimeInstallLogSubject.next(log);
 		});
 	}
 
-	async init() {
+	async initLogFile() {
 		try {
 			let fd = await fs.open(this.logFilePath, 'w');
 			fd.close();

--- a/desktop/workspaces/electron-app/main/the-machine/os_manager.ts
+++ b/desktop/workspaces/electron-app/main/the-machine/os_manager.ts
@@ -14,6 +14,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 import { join } from 'path';
+import { execSync, exec } from 'child_process';
 
 const username = os.userInfo().username;
 
@@ -64,24 +65,40 @@ export class OSManager {
 		let exePath = join(this.assetFolder, 'dapper.exe');
 
 		const command = `"${exePath}" --var-username=${username} --var-assetfolder=${this.assetFolder} run "${join(this.assetFolder, 'app.json')}" > "${this.logFilePath}" 2>&1`;
-		await this.executeCommand(command);
+		if (isAdminWindows()) {
+			console.info('Already admin - running command normally');
+			await this.executeCommand(command);
+		} else {
+			console.info('Not an admin - running command with sudo prompt');
+			await this.executeCommandSudoPrompt(command);
+		}
 	}
 
 	async setupLinux(): Promise<void> {
 		let exePath = join(this.assetFolder, 'dapper');
 
 		const command = `"${exePath}" --var-username=${username} --var-assetfolder=${this.assetFolder} run "${join(this.assetFolder, 'app.json')}" > "${this.logFilePath}" 2>&1`;
-		await this.executeCommand(command);
+		await this.executeCommandSudoPrompt(command);
 	}
 
 	private async executeCommand(command: string): Promise<void> {
+		return new Promise((resolve, reject) => {
+			exec(command, (error, stdout, stderr) => {
+				if (error) {
+					reject(error);
+				} else {
+					resolve();
+				}
+			});
+		});
+	}
+
+	private async executeCommandSudoPrompt(command: string): Promise<void> {
 		return new Promise((resolve, reject) => {
 			sudo.exec(
 				command,
 				{
 					name: 'Singulatron Environment Setup',
-					// @todo fix icon
-					// icns: '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertStopIcon.icns'
 					icns: getIconPath(this.assetFolder),
 				},
 				(error, stdout, stderr) => {
@@ -141,5 +158,16 @@ class FileWatcher {
 
 	watchFile() {
 		setInterval(() => this.readFile(), 500);
+	}
+}
+
+function isAdminWindows(): boolean {
+	try {
+		// Attempt to execute a command that requires administrative privileges.
+		execSync('net session', { stdio: 'ignore' });
+		return true;
+	} catch (error) {
+		// If the command fails, assume the user does not have administrative privileges.
+		return false;
 	}
 }

--- a/localtron/dapper/app/configuration_manager.go
+++ b/localtron/dapper/app/configuration_manager.go
@@ -22,6 +22,7 @@ import (
 
 // ConfigurationManager manages configurations and feature dependencies.
 type ConfigurationManager struct {
+	stream                 bool
 	Features               map[string]dt.Feature
 	CurrentPlatform        dt.Platform
 	CacheFolder            string
@@ -48,6 +49,7 @@ func NewConfigurationManager(fs map[string]dt.Feature) *ConfigurationManager {
 	cm := &ConfigurationManager{
 		Features: fs,
 		Printf:   fmt.Printf,
+		stream:   true,
 	}
 
 	// check os

--- a/localtron/dapper/app/load_app.go
+++ b/localtron/dapper/app/load_app.go
@@ -31,9 +31,9 @@ func (cm *ConfigurationManager) LoadAppConfiguration(filePath string) (*dt.App, 
 	}
 
 	if app.Name != "" {
-		cm.Printf("Processing app '%s' (%s). Cache folder: '%v'.\n", app.Name, filePath, cm.CacheFolder)
+		cm.Printf("Processing app '%s' (%s).\n", app.Name, filePath)
 	} else {
-		cm.Printf("Processing unnamed app (%s). Cache folder: '%v'.\n", filePath, cm.CacheFolder)
+		cm.Printf("Processing unnamed app (%s).\n", filePath)
 	}
 
 	return &app, nil

--- a/localtron/dapper/app/run.go
+++ b/localtron/dapper/app/run.go
@@ -315,7 +315,7 @@ func executeScript(subs map[string]string, script *dt.Script) (bool, string, str
 	case "cmd":
 		cmd = exec.Command("cmd", "/C", source)
 	case "powershell":
-		cmd = exec.Command("powershell", "-Command", `$env:WSL_UTF8=1\n`+source)
+		cmd = exec.Command("powershell", "-Command", `$env:WSL_UTF8=1;`+source)
 	case "bash":
 		cmd = exec.Command("bash", "-c", source)
 	default:
@@ -345,7 +345,7 @@ func executeScriptStreamed(subs map[string]string, script *dt.Script, indentStri
 	case "cmd":
 		cmd = exec.Command("cmd", "/C", source)
 	case "powershell":
-		cmd = exec.Command("powershell", "-Command", `$env:WSL_UTF8=1\n`+source)
+		cmd = exec.Command("powershell", "-Command", `$env:WSL_UTF8=1;`+source)
 	case "bash":
 		cmd = exec.Command("bash", "-c", source)
 	default:

--- a/localtron/dapper/app/run.go
+++ b/localtron/dapper/app/run.go
@@ -315,7 +315,7 @@ func executeScript(subs map[string]string, script *dt.Script) (bool, string, str
 	case "cmd":
 		cmd = exec.Command("cmd", "/C", source)
 	case "powershell":
-		cmd = exec.Command("powershell", "-Command", `$env:WSL_UTF8=1;`+source)
+		cmd = exec.Command("powershell", "-Command", `$env:WSL_UTF8=1; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; `+source)
 	case "bash":
 		cmd = exec.Command("bash", "-c", source)
 	default:

--- a/localtron/dapper/app/run.go
+++ b/localtron/dapper/app/run.go
@@ -214,7 +214,7 @@ func (cm *ConfigurationManager) recurse(feature *dt.Feature, featureInvocation *
 		return nil
 	}
 
-	cm.Printf(`%s<- "%v" is OK.\n`, indent, feature.Name)
+	cm.Printf("%s<- \"%v\" is OK.\n", indent, feature.Name)
 
 	return nil
 }
@@ -345,7 +345,7 @@ func executeScriptStreamed(subs map[string]string, script *dt.Script, indentStri
 	case "cmd":
 		cmd = exec.Command("cmd", "/C", source)
 	case "powershell":
-		cmd = exec.Command("powershell", "-Command", `$env:WSL_UTF8=1;`+source)
+		cmd = exec.Command("powershell", "-Command", `$env:WSL_UTF8=1; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; `+source)
 	case "bash":
 		cmd = exec.Command("bash", "-c", source)
 	default:

--- a/localtron/dapper/features/docker_daemon_running.go
+++ b/localtron/dapper/features/docker_daemon_running.go
@@ -36,7 +36,7 @@ var DockerDaemonRunning = dt.Feature{
 # Function to check if the Docker daemon is running in WSL
 function Check-DockerDaemon {
 	$dockerStatus = wsl -d ` + nameOfDistro + ` -e /bin/ash -c "ps aux | grep dockerd | grep -v grep"
-	if ($dockerStatus.Contains("dockerd")) {
+	if ($null -ne $dockerStatus -and $dockerStatus.Contains("dockerd")) {
 		return $true
 	} else {
 		return $false

--- a/localtron/dapper/features/wsl_tar_loaded.go
+++ b/localtron/dapper/features/wsl_tar_loaded.go
@@ -44,11 +44,12 @@ wsl -s {{.distroname}}
 				Source: `
 $distroname = "{{.distroname}}"
 $loadedDistros = wsl -l -q
-if ($loadedDistros.Contains($distroname)) {
+if ($null -ne $loadedDistros -and $loadedDistros.Contains($distroname)) {
     Write-Host "$distroname is already loaded."
     exit 0
 } else {
     Write-Host "$distroname is not loaded."
+	Write-Host "wsl -l -q output: $loadedDistros"
     exit 1
 }
 `,

--- a/localtron/services/docker/info.go
+++ b/localtron/services/docker/info.go
@@ -162,12 +162,12 @@ func getWslIpAddress() (string, error) {
 	if runtime.GOOS != "windows" {
 		return "", fmt.Errorf("not a Windows system")
 	}
-	source := `wsl ip addr show eth0`
 
-	cmd := exec.Command("powershell", "-Command", "$env:WSL_UTF8=1; "+source)
+	cmd := exec.Command("wsl", "ip", "addr", "show", "eth0")
 
 	// this doesn't seem to work to fix the UTF8 issue but I'll still leave it here
 	cmd.Env = append(cmd.Env, "WSL_UTF8=1")
+
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()

--- a/localtron/services/docker/info.go
+++ b/localtron/services/docker/info.go
@@ -161,6 +161,7 @@ func getWslIpAddress() (string, error) {
 	}
 
 	cmd := exec.Command("wsl", "ip", "addr", "show", "eth0")
+	cmd.Env = append(cmd.Env, "WSL_UTF8=1")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()

--- a/localtron/services/docker/info.go
+++ b/localtron/services/docker/info.go
@@ -162,8 +162,11 @@ func getWslIpAddress() (string, error) {
 	if runtime.GOOS != "windows" {
 		return "", fmt.Errorf("not a Windows system")
 	}
+	source := `wsl ip addr show eth0`
 
-	cmd := exec.Command("wsl", "ip", "addr", "show", "eth0")
+	cmd := exec.Command("powershell", "-Command", "$env:WSL_UTF8=1; "+source)
+
+	// this doesn't seem to work to fix the UTF8 issue but I'll still leave it here
 	cmd.Env = append(cmd.Env, "WSL_UTF8=1")
 	var out bytes.Buffer
 	cmd.Stdout = &out

--- a/localtron/services/docker/pull_image.go
+++ b/localtron/services/docker/pull_image.go
@@ -18,7 +18,6 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
@@ -86,7 +85,7 @@ type PullStatus struct {
 }
 
 func pullImageWithProgress(d *client.Client, imageName string) error {
-	rc, err := d.ImagePull(context.Background(), imageName, types.ImagePullOptions{})
+	rc, err := d.ImagePull(context.Background(), imageName, image.PullOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to pull image")
 	}

--- a/localtron/services/docker/pull_image.go
+++ b/localtron/services/docker/pull_image.go
@@ -63,7 +63,7 @@ func (d *DockerService) pullImage(imageName string) error {
 		return nil
 	}
 
-	lib.Logger.Info("Pulling! image", slog.String("image", imageName))
+	lib.Logger.Info("Starting to pull image", slog.String("image", imageName))
 
 	err = pullImageWithProgress(d.client, imageName)
 	if err != nil {
@@ -105,6 +105,10 @@ func pullImageWithProgress(d *client.Client, imageName string) error {
 		if err := decoder.Decode(&status); err == io.EOF {
 			break
 		} else if err != nil {
+			lib.Logger.Error("Error pulling image",
+				slog.String("error", err.Error()),
+				slog.String("image", imageName),
+			)
 			return errors.Wrap(err, "Failed to decode image pull output")
 		}
 		logPullProgress(status)


### PR DESCRIPTION
- Dapper now streams output to better follow long running processes and be more responsive
- Various dapper feature fixes - mainly `FileDownloaded`
- To prevent slow exe uploads, win builds now only upload a few files instead of full folders
- Added timeouts to builds
- Fixed zoom feature introduced exception in nodejs
- If already an admin, sudo-prompt is not used, instead a simple exec_command is invoked - only on windows for now